### PR TITLE
🚀 rulesyncの自動更新フックを追加

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,11 @@ repos:
   # Optional: rulesync drift check
   - repo: local
     hooks:
+      - id: rulesync-update
+        name: rulesync apply (auto-update)
+        language: system
+        entry: bash -lc 'bash scripts/rulesync-update.sh'
+        pass_filenames: false
       - id: rulesync-check
         name: rulesync check drift
         language: system

--- a/scripts/rulesync-update.sh
+++ b/scripts/rulesync-update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Guard: rulesync 未インストールならスキップ
+if ! command -v rulesync >/dev/null 2>&1; then
+  echo "rulesync not installed; skipping update (install to enable)."
+  exit 0
+fi
+
+# Guard: 設定ファイルが無ければスキップ
+CONFIG=".rulesync.yaml"
+if [ ! -f "$CONFIG" ]; then
+  CONFIG=".rulesync.yml"
+fi
+if [ ! -f "$CONFIG" ]; then
+  echo "No .rulesync.yaml found; skipping update."
+  exit 0
+fi
+
+# Guard: 雛形のままならスキップ（例の文字列に依存）
+if grep -q "your-org/your-rules-repo" "$CONFIG"; then
+  echo "rulesync config looks like a placeholder; skipping update."
+  exit 0
+fi
+
+# Apply 実行
+exec rulesync apply


### PR DESCRIPTION

## 📒 変更の概要

- `rulesync-update`フックを`.pre-commit-config.yaml`に追加しました。
- 新しいスクリプトファイル`rulesync-update.sh`を作成し、`rulesync`の自動更新を実行します。

## ⚒ 技術的詳細

- `.pre-commit-config.yaml`に以下のフックを追加しました:
  - `rulesync-update`: `rulesync`の自動更新を行うフックです。システムの`bash`を使用して、`scripts/rulesync-update.sh`を実行します。
  
- `scripts/rulesync-update.sh`スクリプトの内容:
  - `rulesync`がインストールされているか確認します。
  - 設定ファイル`.rulesync.yaml`または`.rulesync.yml`が存在するか確認します。
  - 設定ファイルがプレースホルダーでないことを確認します。
  - すべての条件を満たした場合に`rulesync apply`を実行します。

## ⚠ 注意点

- 💡 `rulesync`がインストールされていない場合、スクリプトは更新をスキップします。
- ⚠ 設定ファイルが存在しない場合や、プレースホルダーのままの場合も更新は行われません。