### PR TITLE
🚀 EditorConfigルールの追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,3 +22,6 @@ indent_size = 2
 
 [Makefile]
 indent_style = tab
+
+[justfile]
+indent_size = 4


### PR DESCRIPTION

このプルリクエストでは、`justfile`に対するEditorConfigルールを追加しました。

## 📒 変更の概要

1. ✏️ `justfile`に対してインデントサイズを4に設定するルールを追加しました。

## ⚒ 技術的詳細

1. 🛠️ `.editorconfig`ファイルに以下の変更を加えました:
   - `justfile`セクションを追加し、`indent_size`を4に設定しました。

## ⚠ 注意点

1. ⚠️ この変更は、`justfile`を使用するプロジェクトにおいて、インデントスタイルが統一されることを目的としています。既存のファイルがこのルールに従っていない場合、手動で修正が必要になる可能性があります。