### PR TITLE
Fix tfcmt target path for Terraform plan comment

### DIFF
--- a/.github/actions/terraform-plan/action.yml
+++ b/.github/actions/terraform-plan/action.yml
@@ -55,7 +55,7 @@ runs:
           *) TF_PLAN_STATUS="unknown-error" ;;
         esac
 
-        TARGET=$(echo ${{ inputs.working-directory }} | sed -e 's|^.*terraform/environments/||' | cut -c 1-36)
+        TARGET=$(echo ${{ inputs.working-directory }} | sed -e 's|^.*terraform/envs/||' | cut -c 1-36)
         tfcmt --var target:$TARGET plan -patch -- cat tf_plan.txt
 
         echo "TF_PLAN_STATUS=$TF_PLAN_STATUS"


### PR DESCRIPTION
## Summary
- adjust the tfcmt target derivation to strip the infra/terraform/envs prefix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e047f88efc8321bfb4173ba7652679