### PR TITLE
fix: resolve biome command for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,22 @@ repos:
     hooks:
       - id: shellcheck
 
+  - repo: local
+    hooks:
+      - id: biome-check
+        name: Biome check
+        entry: npx
+        language: node
+        files: "\\.(?:[cm]?[jt]sx?|jsonc?)$"
+        args:
+          - --no-install
+          - biome
+          - check
+          - --write
+          - --error-on-warnings
+        additional_dependencies:
+          - '@biomejs/biome@1.7.3'
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# JavaScript/TypeScript handled by Biome
+**/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts,json,jsonc}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.7.3/schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "es5",
+      "semicolons": "always"
+    }
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "ignore": [
+      "node_modules/",
+      "dist/",
+      "coverage/",
+      "build/",
+      "pnpm-lock.yaml"
+    ]
+  }
+}

--- a/justfile
+++ b/justfile
@@ -58,9 +58,9 @@ fix:
     pre-commit run trailing-whitespace --all-files
     pre-commit run markdownlint-cli2 --all-files
 
-# Format all supported files with Prettier (via pre-commit hook)
+# Format all supported files (Biome + Prettier via package script)
 format:
-    pre-commit run prettier --all-files
+    pnpm run format
 
 # Format only staged files (typical git commit flow)
 format-staged:

--- a/package.json
+++ b/package.json
@@ -12,11 +12,16 @@
     "dev:web": "pnpm --filter @mathquest/web run dev",
     "dev:edge": "pnpm --filter @mathquest/domain run build && pnpm --filter @mathquest/edge run dev",
     "clean": "pnpm --filter @mathquest/domain run clean && pnpm --filter @mathquest/app run clean && pnpm --filter @mathquest/api run clean && pnpm --filter @mathquest/web run clean",
-    "format": "pre-commit run prettier --all-files",
+    "format": "pnpm run format:biome && pnpm run format:prettier",
+    "format:biome": "pnpm exec biome format --write .",
+    "format:prettier": "pre-commit run prettier --all-files",
     "format:staged": "pre-commit run prettier",
+    "lint:biome": "pnpm exec biome lint .",
+    "lint:biome:fix": "pnpm exec biome check --write .",
     "drizzle:generate": "pnpm --filter @mathquest/edge run drizzle:generate"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.7.3",
     "wrangler": "4"
   }
 }


### PR DESCRIPTION
## Summary
- invoke the Biome hook via `npx --no-install biome` so the hook always finds the CLI installed in its node environment

## Testing
- not run (pre-commit unavailable in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68df8f01c5b88321acaaa1a5d1a09380