### PR TITLE
Fix GitHubリンクをフッターに更新する

### DIFF
--- a/apps/edge/src/views/layouts/document.tsx
+++ b/apps/edge/src/views/layouts/document.tsx
@@ -108,7 +108,7 @@ export const Document: FC<DocumentProps> = ({
             class="mx-auto flex w-full max-w-6xl flex-col gap-2 px-4 py-6 text-xs text-[#5e718a] sm:flex-row sm:items-center sm:justify-between"
           >
             <a
-              href="https://github.com/takeruooyama/mathquest"
+              href="https://github.com/tqer39/mathquest"
               class="inline-flex items-center gap-2 font-semibold text-[var(--mq-primary-strong)] transition hover:-translate-y-0.5 hover:text-[var(--mq-ink)]"
               target="_blank"
               rel="noreferrer"


### PR DESCRIPTION

## 📒 変更の概要

- フッター内のGitHubリンクを更新しました。以前のリンクは `https://github.com/takeruooyama/mathquest` でしたが、現在は `https://github.com/tqer39/mathquest` に変更されています。

## ⚒ 技術的詳細

- 変更は `apps/edge/src/views/layouts/document.tsx` ファイル内で行われました。具体的には、リンクの `href` 属性が更新されています。

```diff
-              href="https://github.com/takeruooyama/mathquest"
+              href="https://github.com/tqer39/mathquest"
```

## ⚠ 注意点

- 💡 この変更はリンクの修正のみであり、他の機能やスタイルには影響を与えません。