### PR TITLE
🚀 MathQuestのローカルD1マイグレーションコマンドのドキュメントを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,34 @@
-# boilerplate-base
+# MathQuest
 
-A base boilerplate template for projects with pre-configured development tools and workflows.
+MathQuest is an elementary-school math learning platform built on a Hono-based SSR application that targets Cloudflare Workers.
+The repository bundles the edge runtime, supporting API/frontend packages, and Terraform-managed infrastructure so the team can
+iterate on product, platform, and operations from a single mono-repo.
 
 ## Quick Start
 
 ### Prerequisites
 
-This project uses different tools for different purposes:
+This project relies on a small toolchain:
 
-- **Homebrew**: System-level development tools
-- **mise**: Programming language version management
-- **just**: Task automation and command runner
+- **Homebrew** (macOS/Linux): System-level development tools (mise, just, git, pre-commit, uv, etc.)
+- **mise**: Installs the runtime tool versions declared in `.tool-versions` (Node.js 22, pnpm 10, Terraform, Wrangler)
+- **just**: Task runner that wires the setup/lint/dev workflows
+- **pnpm**: JavaScript package manager used across the workspace (installed via mise during `just setup`)
 
 ### Setup
 
 ```bash
-# 1. Install Homebrew (if not already installed)
+# 1. (macOS/Linux) Install Homebrew and Brewfile packages
 make bootstrap
 
-# 2. Install all development tools
-brew bundle install
-
-# 3. Setup development environment
+# 2. Install language/toolchain versions and JS dependencies via mise + pnpm
 just setup
 ```
 
-**Alternative one-command setup** (if Homebrew is already installed):
+If Homebrew is already installed you can skip `make bootstrap` and instead run:
 
 ```bash
+brew bundle install
 just setup
 ```
 
@@ -59,10 +60,11 @@ just status
 
 This setup clearly separates tool responsibilities:
 
-- **brew**: System-level development tools (git, pre-commit, mise, just, uv)
-- **mise**: Node.js version management only
-- **uv**: Python package and project management
-- **pre-commit**: Handles all linting tools automatically (no need to install separately)
+- **brew**: System-level development tools (git, pre-commit, mise, just, uv, rulesync, cf-vault, aws-vault)
+- **mise**: Installs runtime tools defined in `.tool-versions` (Node.js, pnpm, Terraform, Wrangler)
+- **pnpm**: Manages JavaScript/TypeScript workspaces under `apps/` and `packages/`
+- **uv**: Python package and project management (used for supporting scripts)
+- **pre-commit**: Runs all linting/formatting hooks automatically (no need to install each hook manually)
 
 ### Optional AI CLI Tools
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -43,7 +43,9 @@ Wrangler を使って Cloudflare Workers をローカル実行します。KV/D1 
 - D1 のローカル準備（任意）
   - DB 作成: `wrangler d1 create mathquest`
   - 生成された `database_id` を `apps/edge/wrangler.toml` の `d1_databases` に反映
-  - マイグレーションがある場合: `wrangler d1 migrations apply mathquest`
+  - マイグレーション適用: `wrangler d1 migrations apply DB --local --config apps/edge/wrangler.toml`
+    - `DB` は `wrangler.toml` の `binding` 名を指し、`--config` で設定ファイルを指定することで `infra/migrations` 配下の SQL が適用されます。
+    - `--local` フラグにより、ローカル SQLite ファイルに対してマイグレーションが実行されるため、Wrangler のプレビュー環境に影響を与えません。
   - スキーマ変更時は `pnpm drizzle:generate` で SQL を生成し、上記コマンドで適用
 - データ永続化（開発用）
   - `wrangler dev --persist` を使うと KV/D1 のローカルデータを `.wrangler` ディレクトリに保持できます。


### PR DESCRIPTION

## 📒 変更の概要

- `local-dev.md`にD1マイグレーションコマンドの詳細を追加しました。
  - マイグレーション適用コマンドを`wrangler d1 migrations apply DB --local --config apps/edge/wrangler.toml`に更新しました。
  - `DB`は`wrangler.toml`の`binding`名を指し、`--config`オプションで設定ファイルを指定することで、`infra/migrations`配下のSQLが適用されることを明記しました。
  - `--local`フラグにより、ローカルSQLiteファイルに対してマイグレーションが実行され、Wranglerのプレビュー環境に影響を与えないことを説明しました。

- `README.md`を更新し、MathQuestプロジェクトの概要を明確にしました。
  - プロジェクトの目的や使用するツールについての説明を追加しました。
  - セットアップ手順を整理し、Homebrewが既にインストールされている場合の代替手順を提供しました。

## ⚒ 技術的詳細

- `local-dev.md`の更新により、D1マイグレーションの実行方法が明確になり、開発者がローカル環境での作業をよりスムーズに行えるようになります。
- `README.md`の改善により、新しい開発者がプロジェクトに参加しやすくなり、必要なツールやセットアップ手順が明確に示されています。

## ⚠ 注意点

> [!IMPORTANT]
>
> - 新しいマイグレーションコマンドを使用する際は、`--local`フラグを忘れずに指定してください。これにより、ローカル環境での作業が安全に行えます。