### PR TITLE
🚫 AI CLIツールセクションの削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,6 @@ This setup clearly separates tool responsibilities:
 - **uv**: Python package and project management (used for supporting scripts)
 - **pre-commit**: Runs all linting/formatting hooks automatically (no need to install each hook manually)
 
-### Optional AI CLI Tools
-
-`just setup` no longer installs AI development CLIs automatically. Install them manually if you want the tooling support (for example: `mise exec node -- npm install -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex`).
-
-- **Claude Code CLI**: `@anthropic-ai/claude-code` - For AI-assisted development
-- **Gemini CLI**: `@google/gemini-cli` - Alternative AI assistant
-- **OpenAI Codex CLI**: `@openai/codex` - OpenAI CLI for code workflows
-
-Keeping the installation manual lets each developer decide which AI tools to keep in their environment.
-
 ## Optional: rulesync
 
 If you want to synchronize common config files from an external rules repository, see `docs/RULESYNC.ja.md` for setup and usage.

--- a/docs/CLAUDE.ja.md
+++ b/docs/CLAUDE.ja.md
@@ -118,13 +118,6 @@ pre-commit run --all-files
 - **uv**: Pythonパッケージ・プロジェクト管理
 - **pre-commit**: すべてのリンティングツールを自動処理（個別インストール不要）
 
-### 自動CLIツールインストール
-
-`just setup`の実行時に、AI CLIツールが自動的にインストールされます：
-
-- **Claude Code CLI**: `@anthropic-ai/claude-code` - AI支援開発用
-- **Gemini CLI**: `@google/gemini-cli` - 代替AIアシスタント
-
 ### 依存関係管理
 
 - **Renovate**: 依存関係の自動更新は`renovate.json5`を通じて設定され、`github>tqer39/renovate-config`から拡張されています

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -64,16 +64,6 @@ just status
 - **uv**: Pythonパッケージ・プロジェクト管理
 - **pre-commit**: すべてのリンティングツールを自動処理（個別インストール不要）
 
-### AI CLI ツール（任意）
-
-`just setup` では AI 開発ツールを自動インストールしません。必要な開発者だけが個別に導入してください（例：`mise exec node -- npm install -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex`）。
-
-- **Claude Code CLI**: `@anthropic-ai/claude-code` - AI 支援開発用
-- **Gemini CLI**: `@google/gemini-cli` - 代替 AI アシスタント
-- **OpenAI Codex CLI**: `@openai/codex` - OpenAI 製のコード向け CLI
-
-それぞれの開発者が好みの AI ツールを選べるようにするための方針です。
-
 ## 追加ツール: rulesync（任意導入）
 
 - 共通設定ファイルを外部リポジトリから同期するための CLI。


### PR DESCRIPTION

## Pull Request Description

### 📒 変更の概要

- `README.md`、`docs/CLAUDE.ja.md`、および `docs/README.ja.md` からAI CLIツールに関するセクションを削除しました。
- これにより、`just setup` コマンドが自動的にAI CLIツールをインストールしないことが明確になりました。開発者は必要に応じて手動でインストールする必要があります。

### ⚒ 技術的詳細

- `README.md` では、AI CLIツールのインストール手順が削除され、各開発者が自分の環境に必要なツールを選択できるようになりました。
- `docs/CLAUDE.ja.md` と `docs/README.ja.md` でも同様の変更が行われ、AI CLIツールに関する情報が削除されました。

### ⚠ 注意点

- 💡 この変更により、AI CLIツールのインストールが自動で行われなくなるため、開発者は必要なツールを手動でインストールする必要があります。